### PR TITLE
Filter tabfile columns

### DIFF
--- a/library/programstate.py
+++ b/library/programstate.py
@@ -43,7 +43,7 @@ class FileFormat():
 
     @staticmethod
     def rename_columns(name: str) -> str:
-        regex = "([a-zA-Z0-9_-])"
+        regex = "([a-zA-Z0-9_-]+)"
         name = ''.join(re.findall(regex, name))
         if "sequence" in name:
             return "sequence"

--- a/library/programstate.py
+++ b/library/programstate.py
@@ -43,6 +43,8 @@ class FileFormat():
 
     @staticmethod
     def rename_columns(name: str) -> str:
+        regex = "([a-zA-Z0-9_-])"
+        name = ''.join(re.findall(regex, name))
         if "sequence" in name:
             return "sequence"
         else:
@@ -113,7 +115,7 @@ class FastaFormat(FileFormat):
             if len(table) == 0:
                 break
             yield table.drop_duplicates(subset='seqid').copy()
-            
+
 
 
 


### PR DESCRIPTION
Only keep alphanumericals, underscores and hyphens.
This prevents hidden characters like BOM from
interfering with column-matching. Closes #62.