### PR TITLE
Pyinstaller support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
+# *.spec
 
 # Installer logs
 pip-log.txt

--- a/library/gui.py
+++ b/library/gui.py
@@ -13,6 +13,8 @@ from library.programstate import *
 from library.gui_utils import display_errors_and_warnings
 from library.plot_taxi import Plot
 
+resource_path = getattr(sys, '_MEIPASS', sys.path[0])
+
 
 class TaxiGUI(ttk.Frame):
 
@@ -69,7 +71,7 @@ class TaxiGUI(ttk.Frame):
     def load_images(self, image_dict: Dict[str, str]) -> None:
         for key, file in image_dict.items():
             self.images[key] = tk.PhotoImage(
-                file=os.path.join(sys.path[0], "data", file))
+                file=os.path.join(resource_path, "data", file))
 
     def create_top_frame(self) -> None:
         top_frame = ttk.Frame(self, relief="sunken", padding=4)
@@ -106,7 +108,7 @@ class TaxiGUI(ttk.Frame):
         ttk.Separator(top_frame, orient="vertical").grid(
             row=0, column=11, sticky="nsew")
         self.images["logo"] = tk.PhotoImage(file=os.path.join(
-            sys.path[0], "data", "iTaxoTools Digital linneaeus MICROLOGO.png"))
+            resource_path, "data", "iTaxoTools Digital linneaeus MICROLOGO.png"))
         ttk.Label(top_frame, image=self.images["logo"]).grid(
             row=0, column=12, sticky="nse")
 

--- a/library/seq.py
+++ b/library/seq.py
@@ -1,12 +1,15 @@
 from typing import Tuple, Optional
 from Bio.Align import PairwiseAligner
 import os
+import sys
 import math
 import numpy as np
 import re
 
+resource_path = getattr(sys, '_MEIPASS', sys.path[0])
 
-with open(os.path.join('data', 'scores.tab')) as scores_file:
+
+with open(os.path.join(resource_path, 'data', 'scores.tab')) as scores_file:
     scores_dict = {}
     for line in scores_file:
         score_name, _, val = line.partition('\t')

--- a/taxi2.py
+++ b/taxi2.py
@@ -9,6 +9,7 @@ import multiprocessing
 
 from library.gui import TaxiGUI
 
+resource_path = getattr(sys, '_MEIPASS', sys.path[0])
 
 def gui_main() -> None:
     root = tk.Tk()
@@ -20,7 +21,7 @@ def gui_main() -> None:
     root.title("TaxI2")
     if os.name == "nt":
         root.wm_iconbitmap(os.path.join(
-            sys.path[0], 'data', 'TaxI2.ico'))
+            resource_path, 'data', 'TaxI2.ico'))
 
     root.protocol("WM_DELETE_WINDOW", close_window)
     root.rowconfigure(0, weight=1)

--- a/taxi2.spec
+++ b/taxi2.spec
@@ -1,0 +1,33 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(['taxi2.py'],
+             binaries=[],
+             datas=[('data','data')],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+         a.scripts,
+         a.binaries,
+         a.zipfiles,
+         a.datas,
+         [],
+         name='taxi2',
+         debug=False,
+         bootloader_ignore_signals=False,
+         strip=False,
+         upx=True,
+         upx_exclude=[],
+         runtime_tmpdir=None,
+         console=False,
+         icon='data/TaxI2.ico' )


### PR DESCRIPTION
I am not sure if this is still our preferred method of compiling the standalone tools, but I had to modify the code to properly compile with Pyinstaller. It might be a good idea to merge these changes to facilitate compilation in the future. Running `pyinstaller taxi2.spec` should now automatically include the data folder and compile everything under a single executable with an icon.